### PR TITLE
updated User call in createDummyUser to reflect updated constructor

### DIFF
--- a/budget-planning-backend/src/main/java/org/launchcode/budget_planning_backend/models/DummyObjectsToBeDeleted.java
+++ b/budget-planning-backend/src/main/java/org/launchcode/budget_planning_backend/models/DummyObjectsToBeDeleted.java
@@ -34,7 +34,7 @@ public class DummyObjectsToBeDeleted {
 
     public static AccountType createDummyUser() {
         LocalDate date = LocalDate.of(2003, 5, 10);
-        User user1 = new User("Cat", "Adams", date, "catadams", "password", "cat@cat.com");
+        User user1 = new User("Cat", "Adams", date, "cat@cat.com", "catadams", "password", "password");
         AccountTypeUtil.determineAccountType(user1);
         return user1.getAccountType();
     }


### PR DESCRIPTION
I didn't notice until after I had closed the "set-acct-type-method" branch that the dummy user I created no longer matched the updated User constructor. This is just to fix that so it can be used if needed.